### PR TITLE
Add middleware for request ID and enhanced access logging

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -60,6 +60,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1b8e56985ec62d17e9c1001dc89c88ecd7dc08e47eba5ec7c29c7b5eeecde967"
 
 [[package]]
+name = "bumpalo"
+version = "3.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46c5e41b57b8bba42a04676d81cb89e9ee8e859a1a66f80a5a72e1cb76b34d43"
+
+[[package]]
 name = "bytes"
 version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -120,6 +126,18 @@ dependencies = [
  "futures-task",
  "pin-project-lite",
  "pin-utils",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26145e563e54f2cadc477553f1ec5ee650b00862f0a58bcd12cbdc5f0ea2d2f4"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi",
+ "wasi 0.14.2+wasi-0.2.4",
 ]
 
 [[package]]
@@ -258,6 +276,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
 
 [[package]]
+name = "js-sys"
+version = "0.3.77"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1cfaf33c695fc6e08064efbc1f72ec937429614f25eef83af942d0e227c3a28f"
+dependencies = [
+ "once_cell",
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "lazy_static"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -316,7 +344,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "78bed444cc8a2160f01cbcf811ef18cac863ad68ae8ca62092e8db51d51c761c"
 dependencies = [
  "libc",
- "wasi",
+ "wasi 0.11.0+wasi-snapshot-preview1",
  "windows-sys 0.59.0",
 ]
 
@@ -396,8 +424,10 @@ dependencies = [
  "serde",
  "serde_yaml_ng",
  "tokio",
+ "tower",
  "tracing",
  "tracing-subscriber",
+ "uuid",
 ]
 
 [[package]]
@@ -417,6 +447,12 @@ checksum = "1885c039570dc00dcb4ff087a89e185fd56bae234ddc7f056a945bf36467248d"
 dependencies = [
  "proc-macro2",
 ]
+
+[[package]]
+name = "r-efi"
+version = "5.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
 
 [[package]]
 name = "redox_syscall"
@@ -476,6 +512,12 @@ name = "rustc-demangle"
 version = "0.1.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "719b953e2095829ee67db738b3bfa9fa368c94900df327b3f07fe6e794d2fe1f"
+
+[[package]]
+name = "rustversion"
+version = "1.0.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a0d197bd2c9dc6e53b84da9556a69ba4cdfab8619eb41a8bd1cc2027a0f6b1d"
 
 [[package]]
 name = "ryu"
@@ -640,6 +682,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "tower"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d039ad9159c98b70ecfd540b2573b97f7f52c3e8d9f8ad57a24b916a536975f9"
+dependencies = [
+ "tower-layer",
+ "tower-service",
+]
+
+[[package]]
+name = "tower-layer"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "121c2a6cda46980bb0fcd1647ffaf6cd3fc79a013de288782836f6df9c48780e"
+
+[[package]]
 name = "tower-service"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -738,6 +796,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "673aac59facbab8a9007c7f6108d11f63b603f7cabff99fabf650fea5c32b861"
 
 [[package]]
+name = "uuid"
+version = "1.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3cf4199d1e5d15ddd86a694e4d0dffa9c323ce759fea589f00fef9d81cc1931d"
+dependencies = [
+ "getrandom",
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "valuable"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -757,6 +826,73 @@ name = "wasi"
 version = "0.11.0+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
+
+[[package]]
+name = "wasi"
+version = "0.14.2+wasi-0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9683f9a5a998d873c0d21fcbe3c083009670149a8fab228644b8bd36b2c48cb3"
+dependencies = [
+ "wit-bindgen-rt",
+]
+
+[[package]]
+name = "wasm-bindgen"
+version = "0.2.100"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1edc8929d7499fc4e8f0be2262a241556cfc54a0bea223790e71446f2aab1ef5"
+dependencies = [
+ "cfg-if",
+ "once_cell",
+ "rustversion",
+ "wasm-bindgen-macro",
+]
+
+[[package]]
+name = "wasm-bindgen-backend"
+version = "0.2.100"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f0a0651a5c2bc21487bde11ee802ccaf4c51935d0d3d42a6101f98161700bc6"
+dependencies = [
+ "bumpalo",
+ "log",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-macro"
+version = "0.2.100"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7fe63fc6d09ed3792bd0897b314f53de8e16568c2b3f7982f468c0bf9bd0b407"
+dependencies = [
+ "quote",
+ "wasm-bindgen-macro-support",
+]
+
+[[package]]
+name = "wasm-bindgen-macro-support"
+version = "0.2.100"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ae87ea40c9f689fc23f209965b6fb8a99ad69aeeb0231408be24920604395de"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wasm-bindgen-backend",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-shared"
+version = "0.2.100"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a05d73b933a847d6cccdda8f838a22ff101ad9bf93e33684f39c1f5f0eece3d"
+dependencies = [
+ "unicode-ident",
+]
 
 [[package]]
 name = "winapi"
@@ -861,3 +997,12 @@ name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
+
+[[package]]
+name = "wit-bindgen-rt"
+version = "0.39.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f42320e61fe2cfd34354ecb597f86f413484a798ba44a8ca1165c58d42da6c1"
+dependencies = [
+ "bitflags",
+]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,5 +10,7 @@ hyper-util = { version = "0.1.14", features = ["full"] }
 serde = { version = "1.0.219", features = ["derive"] }
 serde_yaml_ng = "0.10.0"
 tokio = { version = "1.45.1", features = ["full"] }
+tower = "0.5.2"
 tracing = "0.1.41"
 tracing-subscriber = { version = "0.3.19", features = ["json", "env-filter"] }
+uuid = { version = "1.17.0", features = ["v4"] }

--- a/src/logger.rs
+++ b/src/logger.rs
@@ -28,7 +28,7 @@ pub(crate) fn init_logger(gateway_log_config: &GatewayLog, access_log_config: &A
         };
         let access_log_layer = build_layer(access_log_stream, &access_log_config.format)
             .with_filter(filter_fn(|metadata| {
-                metadata.target() == "access" && metadata.level() == &tracing::Level::INFO
+                metadata.target() == "access" && metadata.level() <= &tracing::Level::INFO
             }))
             .boxed();
         layers.push(access_log_layer);

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,23 +1,29 @@
+use crate::config::GatewayConfig;
+use crate::middleware::{AccessLogger, RequestID};
+use crate::service::HandlerService;
+
+use http_body_util::{BodyExt, Empty, combinators::BoxBody};
+use hyper::client::conn::http1 as http1_client;
+use hyper::server::conn::http1 as http1_server;
+use hyper::{
+    Request, Response, StatusCode, Uri, body::Bytes, body::Incoming, header::HeaderValue,
+    service::service_fn,
+};
+use hyper_util::rt::TokioIo;
 use std::convert::Infallible;
 use std::env;
-use std::net::{IpAddr, Ipv4Addr};
+use std::net::{IpAddr, Ipv4Addr, SocketAddr};
 use std::sync::Arc;
-
-use crate::config::GatewayConfig;
-use http_body_util::combinators::BoxBody;
-use http_body_util::{BodyExt, Empty};
-use hyper::client::conn::http1 as http1_client;
-use hyper::header::HeaderValue;
-use hyper::server::conn::http1 as http1_server;
-use hyper::{Request, Response, body::Bytes, service::service_fn};
-use hyper::{StatusCode, Uri};
-use hyper_util::rt::TokioIo;
-use std::net::SocketAddr;
 use tokio::net::{TcpListener, TcpStream};
+use tower::ServiceBuilder;
 
 mod config;
 
 mod logger;
+
+mod middleware;
+
+mod service;
 
 #[tokio::main]
 async fn main() {
@@ -44,11 +50,16 @@ async fn main() {
 
         let gateway_config = gateway_config.clone();
         tokio::spawn(async move {
+            let client_handler_service =
+                service_fn(move |req| handle_client(req, gateway_config.clone(), addr.ip()));
+            let base_service = ServiceBuilder::new()
+                .layer_fn(RequestID::new)
+                .layer_fn(AccessLogger::new)
+                .service(client_handler_service);
+            let handler_service = HandlerService::new(base_service, addr.ip());
+
             if let Err(err) = http1_server::Builder::new()
-                .serve_connection(
-                    aio,
-                    service_fn(move |req| handle_client(req, gateway_config.clone(), addr.ip())),
-                )
+                .serve_connection(aio, handler_service)
                 .await
             {
                 tracing::error!("Error serving connection: {:?}", err);
@@ -58,7 +69,7 @@ async fn main() {
 }
 
 async fn handle_client(
-    request: Request<hyper::body::Incoming>,
+    request: Request<Incoming>,
     gateway_config: Arc<GatewayConfig>,
     client_ip: IpAddr,
 ) -> Result<Response<BoxBody<Bytes, hyper::Error>>, Infallible> {

--- a/src/main.rs
+++ b/src/main.rs
@@ -150,10 +150,7 @@ async fn handle_client(
                 Err(_) => Ok(response_with_status(StatusCode::BAD_GATEWAY)),
             }
         }
-        Err(status_code) => {
-            tracing::warn!("{}", status_code);
-            Ok(response_with_status(status_code))
-        }
+        Err(status_code) => Ok(response_with_status(status_code)),
     }
 }
 

--- a/src/middleware/access_logger.rs
+++ b/src/middleware/access_logger.rs
@@ -1,0 +1,72 @@
+use crate::middleware::REQUEST_ID_HEADER;
+use hyper::{Request, body::Incoming, header::USER_AGENT, service::Service};
+use std::{net::IpAddr, pin::Pin, str::FromStr, time::Instant};
+
+#[derive(Clone)]
+pub struct AccessLogger<S> {
+    inner: S,
+}
+
+impl<S> AccessLogger<S> {
+    pub fn new(inner: S) -> Self {
+        AccessLogger { inner }
+    }
+}
+
+impl<S> Service<Request<Incoming>> for AccessLogger<S>
+where
+    S: Service<Request<Incoming>> + Clone + Send + 'static,
+    <S as Service<Request<Incoming>>>::Future: Send,
+{
+    type Response = S::Response;
+    type Error = S::Error;
+    type Future = Pin<Box<dyn Future<Output = Result<Self::Response, Self::Error>> + Send>>;
+
+    fn call(&self, req: Request<Incoming>) -> Self::Future {
+        let start = Instant::now();
+        let method = req.method().clone();
+        let path = req.uri().path().to_string();
+        let user_agent = req
+            .headers()
+            .get(USER_AGENT)
+            .and_then(|v| v.to_str().ok())
+            .unwrap_or("-")
+            .to_string();
+        let client_ip = req
+            .extensions()
+            .get::<IpAddr>()
+            .unwrap_or(&IpAddr::from_str("127.0.0.1").unwrap())
+            .to_owned();
+        let request_id = req
+            .headers()
+            .get(REQUEST_ID_HEADER)
+            .and_then(|v| v.to_str().ok())
+            .unwrap_or("-")
+            .to_string();
+
+        let inner = self.inner.clone();
+        Box::pin(async move {
+            let result = inner.call(req).await;
+            let duration = start.elapsed().as_millis();
+            tracing::info!(
+                target: "access",
+                method = %method,
+                path = %path,
+                duration_ms = %duration,
+                client_ip = %client_ip,
+                user_agent = %user_agent,
+                request_id = %request_id,
+            );
+            match result {
+                Ok(res) => {
+                    tracing::info!("Calling after response processing");
+                    Ok(res)
+                }
+                Err(e) => {
+                    tracing::error!("Encountered error while processing");
+                    Err(e)
+                }
+            }
+        })
+    }
+}

--- a/src/middleware/mod.rs
+++ b/src/middleware/mod.rs
@@ -1,0 +1,9 @@
+use hyper::header::HeaderName;
+
+const REQUEST_ID_HEADER: HeaderName = HeaderName::from_static("x-request-id");
+
+mod access_logger;
+mod request_id;
+
+pub use access_logger::AccessLogger;
+pub use request_id::RequestID;

--- a/src/middleware/request_id.rs
+++ b/src/middleware/request_id.rs
@@ -1,0 +1,33 @@
+use crate::middleware::REQUEST_ID_HEADER;
+use hyper::{Request, body::Incoming, http::HeaderValue, service::Service};
+use uuid::Uuid;
+
+#[derive(Clone)]
+pub struct RequestID<S> {
+    inner: S,
+}
+
+impl<S> RequestID<S> {
+    pub fn new(inner: S) -> Self {
+        RequestID { inner }
+    }
+}
+
+impl<S> Service<Request<Incoming>> for RequestID<S>
+where
+    S: Service<Request<Incoming>>,
+{
+    type Response = S::Response;
+    type Error = S::Error;
+    type Future = S::Future;
+
+    fn call(&self, req: Request<Incoming>) -> Self::Future {
+        let request_id = Uuid::new_v4();
+        let mut req = req;
+        req.headers_mut().insert(
+            REQUEST_ID_HEADER,
+            HeaderValue::from_str(&request_id.to_string()).unwrap(),
+        );
+        self.inner.call(req)
+    }
+}

--- a/src/service.rs
+++ b/src/service.rs
@@ -1,0 +1,29 @@
+use hyper::{Request, body::Incoming, service::Service};
+use std::net::IpAddr;
+
+#[derive(Clone)]
+pub struct HandlerService<S> {
+    inner: S,
+    remote_addr: IpAddr,
+}
+
+impl<S> HandlerService<S> {
+    pub fn new(inner: S, remote_addr: IpAddr) -> Self {
+        HandlerService { inner, remote_addr }
+    }
+}
+
+impl<S> Service<Request<Incoming>> for HandlerService<S>
+where
+    S: Service<Request<Incoming>>,
+{
+    type Response = S::Response;
+    type Error = S::Error;
+    type Future = S::Future;
+
+    fn call(&self, req: Request<Incoming>) -> Self::Future {
+        let mut req = req;
+        req.extensions_mut().insert(self.remote_addr);
+        self.inner.call(req)
+    }
+}


### PR DESCRIPTION
This PR adds middleware for better request tracking and access logging:

- Adds a middleware that attaches a unique request ID to each request.
- Improves the access logger to:
  - Log messages up to `INFO` level.
  - Separate logs for successful and failed requests.

These changes help with debugging and understanding the request flow more clearly.