### PR TITLE
feat(server): add TLS support with rustls and enable HTTPS/HTTP2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@
 
 *.yml
 *.log
+*.pem

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -39,6 +39,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
+name = "aws-lc-rs"
+version = "1.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08b5d4e069cbc868041a64bd68dc8cb39a0d79585cd6c5a24caa8c2d622121be"
+dependencies = [
+ "aws-lc-sys",
+ "zeroize",
+]
+
+[[package]]
+name = "aws-lc-sys"
+version = "0.30.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dbfd150b5dbdb988bcc8fb1fe787eb6b7ee6180ca24da683b61ea5405f3d43ff"
+dependencies = [
+ "bindgen",
+ "cc",
+ "cmake",
+ "dunce",
+ "fs_extra",
+]
+
+[[package]]
 name = "backtrace"
 version = "0.3.75"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -60,6 +83,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
+name = "bindgen"
+version = "0.69.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "271383c67ccabffb7381723dea0672a673f292304fcb45c01cc648c7a8d58088"
+dependencies = [
+ "bitflags",
+ "cexpr",
+ "clang-sys",
+ "itertools",
+ "lazy_static",
+ "lazycell",
+ "log",
+ "prettyplease",
+ "proc-macro2",
+ "quote",
+ "regex",
+ "rustc-hash",
+ "shlex",
+ "syn",
+ "which",
+]
+
+[[package]]
 name = "bitflags"
 version = "2.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -78,10 +124,50 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d71b6127be86fdcfddb610f7182ac57211d4b18a3e9c82eb2d17662f2227ad6a"
 
 [[package]]
+name = "cc"
+version = "1.2.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c1599538de2394445747c8cf7935946e3cc27e9625f889d979bfb2aaf569362"
+dependencies = [
+ "jobserver",
+ "libc",
+ "shlex",
+]
+
+[[package]]
+name = "cexpr"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6fac387a98bb7c37292057cffc56d62ecb629900026402633ae9160df93a8766"
+dependencies = [
+ "nom",
+]
+
+[[package]]
 name = "cfg-if"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9555578bc9e57714c812a1f84e4fc5b4d21fcb063490c624de019f7464c91268"
+
+[[package]]
+name = "clang-sys"
+version = "1.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b023947811758c97c59bf9d1c188fd619ad4718dcaa767947df1cadb14f39f4"
+dependencies = [
+ "glob",
+ "libc",
+ "libloading",
+]
+
+[[package]]
+name = "cmake"
+version = "0.1.54"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7caa3f9de89ddbe2c607f4101924c5abec803763ae9534e4f4d7d8f84aa81f0"
+dependencies = [
+ "cc",
+]
 
 [[package]]
 name = "core-foundation"
@@ -100,16 +186,44 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
+name = "dunce"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
+
+[[package]]
+name = "either"
+version = "1.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
+
+[[package]]
 name = "equivalent"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 
 [[package]]
+name = "errno"
+version = "0.3.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "778e2ac28f6c47af28e4907f13ffd1e1ddbd400980a9abd7c8df189bf578a5ad"
+dependencies = [
+ "libc",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
 name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
+
+[[package]]
+name = "fs_extra"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
 
 [[package]]
 name = "futures-channel"
@@ -152,6 +266,17 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
+version = "0.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "335ff9f135e4384c8150d6f27c6daed433577f86b4750418338c01a1a2528592"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "wasi 0.11.1+wasi-snapshot-preview1",
+]
+
+[[package]]
+name = "getrandom"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "26145e563e54f2cadc477553f1ec5ee650b00862f0a58bcd12cbdc5f0ea2d2f4"
@@ -167,6 +292,12 @@ name = "gimli"
 version = "0.31.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "07e28edb80900c19c28f1072f2e8aeca7fa06b23cd4169cefe1af5aa3260783f"
+
+[[package]]
+name = "glob"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8d1add55171497b4705a648c6b583acafb01d58050a51727785f0b2c8e0a2b2"
 
 [[package]]
 name = "h2"
@@ -192,6 +323,15 @@ name = "hashbrown"
 version = "0.15.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5971ac85611da7067dbfcabef3c70ebb5606018acd9e2a3903a0da507521e0d5"
+
+[[package]]
+name = "home"
+version = "0.5.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "589533453244b0995c858700322199b2becb13b627df2851f64a2775d024abcf"
+dependencies = [
+ "windows-sys 0.59.0",
+]
 
 [[package]]
 name = "http"
@@ -314,10 +454,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "469fb0b9cefa57e3ef31275ee7cacb78f2fdca44e4765491884a2b119d4eb130"
 
 [[package]]
+name = "itertools"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba291022dbbd398a455acf126c1e341954079855bc60dfdda641363bd6922569"
+dependencies = [
+ "either",
+]
+
+[[package]]
 name = "itoa"
 version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
+
+[[package]]
+name = "jobserver"
+version = "0.1.33"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38f262f097c174adebe41eb73d66ae9c06b2844fb0da69969647bbddd9b0538a"
+dependencies = [
+ "getrandom 0.3.3",
+ "libc",
+]
 
 [[package]]
 name = "js-sys"
@@ -336,10 +495,32 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
+name = "lazycell"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
+
+[[package]]
 name = "libc"
 version = "0.2.174"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1171693293099992e19cddea4e8b849964e9846f4acee11b3948bcc337be8776"
+
+[[package]]
+name = "libloading"
+version = "0.8.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07033963ba89ebaf1584d767badaa2e8fcec21aedea6b8c0346d487d49c28667"
+dependencies = [
+ "cfg-if",
+ "windows-targets",
+]
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.4.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d26c52dbd32dccf2d10cac7725f8eae5296885fb5703b261f7d0a0739ec807ab"
 
 [[package]]
 name = "lock_api"
@@ -373,6 +554,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a282da65faaf38286cf3be983213fcf1d2e2a58700e808f83f4ea9a4804bc0"
 
 [[package]]
+name = "minimal-lexical"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
+
+[[package]]
 name = "miniz_oxide"
 version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -390,6 +577,16 @@ dependencies = [
  "libc",
  "wasi 0.11.1+wasi-snapshot-preview1",
  "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "nom"
+version = "7.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
+dependencies = [
+ "memchr",
+ "minimal-lexical",
 ]
 
 [[package]]
@@ -471,13 +668,27 @@ dependencies = [
  "http-body-util",
  "hyper",
  "hyper-util",
+ "rustls",
+ "rustls-pemfile",
+ "rustls-pki-types",
  "serde",
  "serde_yaml_ng",
  "tokio",
+ "tokio-rustls",
  "tower",
  "tracing",
  "tracing-subscriber",
  "uuid",
+]
+
+[[package]]
+name = "prettyplease"
+version = "0.2.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "061c1221631e079b26479d25bbf2275bfe5917ae8419cd7e34f13bfc2aa7539a"
+dependencies = [
+ "proc-macro2",
+ "syn",
 ]
 
 [[package]]
@@ -558,10 +769,88 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
 
 [[package]]
+name = "ring"
+version = "0.17.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4689e6c2294d81e88dc6261c768b63bc4fcdb852be6d1352498b114f61383b7"
+dependencies = [
+ "cc",
+ "cfg-if",
+ "getrandom 0.2.16",
+ "libc",
+ "untrusted",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
 name = "rustc-demangle"
 version = "0.1.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "989e6739f80c4ad5b13e0fd7fe89531180375b18520cc8c82080e4dc4035b84f"
+
+[[package]]
+name = "rustc-hash"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
+
+[[package]]
+name = "rustix"
+version = "0.38.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fdb5bc1ae2baa591800df16c9ca78619bf65c0488b41b96ccec5d11220d8c154"
+dependencies = [
+ "bitflags",
+ "errno",
+ "libc",
+ "linux-raw-sys",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "rustls"
+version = "0.23.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2491382039b29b9b11ff08b76ff6c97cf287671dbb74f0be44bda389fffe9bd1"
+dependencies = [
+ "aws-lc-rs",
+ "log",
+ "once_cell",
+ "rustls-pki-types",
+ "rustls-webpki",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-pemfile"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dce314e5fee3f39953d46bb63bb8a46d40c2f8fb7cc5a3b6cab2bde9721d6e50"
+dependencies = [
+ "rustls-pki-types",
+]
+
+[[package]]
+name = "rustls-pki-types"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "229a4a4c221013e7e1f1a043678c5cc39fe5171437c88fb47151a21e6f5b5c79"
+dependencies = [
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-webpki"
+version = "0.103.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0a17884ae0c1b773f1ccd2bd4a8c72f16da897310a98b0e84bf349ad5ead92fc"
+dependencies = [
+ "aws-lc-rs",
+ "ring",
+ "rustls-pki-types",
+ "untrusted",
+]
 
 [[package]]
 name = "rustversion"
@@ -636,6 +925,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "shlex"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
+
+[[package]]
 name = "signal-hook-registry"
 version = "1.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -665,6 +960,12 @@ dependencies = [
  "libc",
  "windows-sys 0.52.0",
 ]
+
+[[package]]
+name = "subtle"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "syn"
@@ -736,6 +1037,16 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "tokio-rustls"
+version = "0.26.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e727b36a1a0e8b74c376ac2211e40c2c8af09fb4013c60d910495810f008e9b"
+dependencies = [
+ "rustls",
+ "tokio",
 ]
 
 [[package]]
@@ -866,12 +1177,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "673aac59facbab8a9007c7f6108d11f63b603f7cabff99fabf650fea5c32b861"
 
 [[package]]
+name = "untrusted"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
+
+[[package]]
 name = "uuid"
 version = "1.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3cf4199d1e5d15ddd86a694e4d0dffa9c323ce759fea589f00fef9d81cc1931d"
 dependencies = [
- "getrandom",
+ "getrandom 0.3.3",
  "js-sys",
  "wasm-bindgen",
 ]
@@ -962,6 +1279,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1a05d73b933a847d6cccdda8f838a22ff101ad9bf93e33684f39c1f5f0eece3d"
 dependencies = [
  "unicode-ident",
+]
+
+[[package]]
+name = "which"
+version = "4.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87ba24419a2078cd2b0f2ede2691b6c66d8e47836da3b6db8265ebad47afbfc7"
+dependencies = [
+ "either",
+ "home",
+ "once_cell",
+ "rustix",
 ]
 
 [[package]]
@@ -1111,3 +1440,9 @@ checksum = "6f42320e61fe2cfd34354ecb597f86f413484a798ba44a8ca1165c58d42da6c1"
 dependencies = [
  "bitflags",
 ]
+
+[[package]]
+name = "zeroize"
+version = "1.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ced3678a2879b30306d323f4542626697a464a97c0a07c9aebf7ebca65cd4dde"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2024"
 [dependencies]
 http-body-util = "0.1.3"
 hyper = { version = "1.6.0", features = ["full"] }
-hyper-util = { version = "0.1.14", features = ["full"] }
+hyper-util = { version = "0.1.14", features = ["full", "server-auto"] }
 serde = { version = "1.0.219", features = ["derive"] }
 serde_yaml_ng = "0.10.0"
 tokio = { version = "1.45.1", features = ["full"] }
@@ -14,3 +14,7 @@ tower = "0.5.2"
 tracing = "0.1.41"
 tracing-subscriber = { version = "0.3.19", features = ["json", "env-filter"] }
 uuid = { version = "1.17.0", features = ["v4"] }
+rustls-pemfile = "2.2.0"
+rustls-pki-types = "1.12.0"
+rustls = "0.23.29"
+tokio-rustls = "0.26.2"

--- a/src/config.rs
+++ b/src/config.rs
@@ -2,7 +2,7 @@ use hyper::StatusCode;
 use serde::{Deserialize, Serialize};
 use std::{fs::File, io::Read};
 
-#[derive(Debug, Serialize, Deserialize, PartialEq)]
+#[derive(Debug, Serialize, Deserialize)]
 pub enum LogFormat {
     #[serde(rename = "common")]
     Common,
@@ -10,20 +10,31 @@ pub enum LogFormat {
     Json,
 }
 
-#[derive(Debug, PartialEq, Serialize, Deserialize)]
+#[derive(Debug, Serialize, Deserialize)]
+pub enum Protocol {
+    #[serde(rename = "http")]
+    Http,
+    #[serde(rename = "https")]
+    Https,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
 pub(crate) struct ServerConfig {
     pub host: String,
     pub port: u16,
+    pub protocol: Protocol,
+    pub cert_file: Option<String>,
+    pub key_file: Option<String>,
 }
 
-#[derive(Debug, PartialEq, Serialize, Deserialize)]
+#[derive(Debug, Serialize, Deserialize)]
 pub(crate) struct GatewayLog {
     pub level: String,
     pub format: LogFormat,
     pub file_path: String,
 }
 
-#[derive(Debug, PartialEq, Serialize, Deserialize)]
+#[derive(Debug, Serialize, Deserialize)]
 pub(crate) struct AccessLog {
     pub enabled: bool,
     pub format: LogFormat,
@@ -37,7 +48,7 @@ pub(crate) struct RouteConfig {
     pub upstream: String,
 }
 
-#[derive(Debug, PartialEq, Serialize, Deserialize)]
+#[derive(Debug, Serialize, Deserialize)]
 pub(crate) struct GatewayConfig {
     pub server: ServerConfig,
     pub log: GatewayLog,

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,20 +1,24 @@
-use crate::config::GatewayConfig;
+use crate::config::{GatewayConfig, Protocol};
 use crate::middleware::{AccessLogger, RequestID};
 use crate::service::HandlerService;
 
-use http_body_util::{BodyExt, Empty, combinators::BoxBody};
+use http_body_util::{BodyExt, Empty, Full, combinators::BoxBody};
 use hyper::client::conn::http1 as http1_client;
 use hyper::server::conn::http1 as http1_server;
 use hyper::{
     Request, Response, StatusCode, Uri, body::Bytes, body::Incoming, header::HeaderValue,
     service::service_fn,
 };
-use hyper_util::rt::TokioIo;
+use hyper_util::rt::{TokioExecutor, TokioIo};
+use hyper_util::server::conn::auto;
+use rustls_pki_types::{CertificateDer, PrivateKeyDer};
 use std::convert::Infallible;
-use std::env;
-use std::net::{IpAddr, Ipv4Addr, SocketAddr};
+use std::net::{IpAddr, SocketAddr};
+use std::str::FromStr;
 use std::sync::Arc;
+use std::{env, fs, io};
 use tokio::net::{TcpListener, TcpStream};
+use tokio_rustls::TlsAcceptor;
 use tower::ServiceBuilder;
 
 mod config;
@@ -37,11 +41,38 @@ async fn main() {
 
     logger::init_logger(&gateway_config.log, &gateway_config.access_log);
 
-    let server_addr = SocketAddr::from((Ipv4Addr::new(0, 0, 0, 0), gateway_config.server.port));
+    let ip_addr = IpAddr::from_str(&gateway_config.server.host).expect("Host must be valid");
+    let server_addr = SocketAddr::from((ip_addr, gateway_config.server.port));
     let listener = TcpListener::bind(server_addr).await.unwrap();
 
-    tracing::info!("Started server at {:?}", server_addr);
+    match gateway_config.server.protocol {
+        Protocol::Http => {
+            tracing::info!("Starting server at http://{:?}", server_addr);
+            start_http_server(listener, gateway_config).await;
+        }
+        Protocol::Https => {
+            tracing::info!("Starting server at https://{:?}", server_addr);
+            let _ = rustls::crypto::aws_lc_rs::default_provider().install_default();
 
+            let cert_file = gateway_config.server.cert_file.as_ref().unwrap_or_else(|| {
+                tracing::error!("Certificate file is required for https");
+                panic!("Certificate file is not provided for https protocol");
+            });
+
+            let key_file = gateway_config.server.key_file.as_ref().unwrap_or_else(|| {
+                tracing::error!("Key file is required for https");
+                panic!("Key file is not provided for https protocol");
+            });
+
+            let certs = load_certs(cert_file).expect("Failed to load certificate");
+            let key = load_private_key(key_file).expect("Failed to load private key");
+
+            start_https_server(listener, gateway_config, certs, key).await;
+        }
+    }
+}
+
+async fn start_http_server(listener: TcpListener, gateway_config: Arc<GatewayConfig>) {
     loop {
         let (stream, addr) = listener.accept().await.unwrap();
         tracing::info!("Connected with client: {}", addr);
@@ -68,6 +99,52 @@ async fn main() {
     }
 }
 
+async fn start_https_server(
+    listener: TcpListener,
+    gateway_config: Arc<GatewayConfig>,
+    certs: Vec<CertificateDer<'static>>,
+    key: PrivateKeyDer<'static>,
+) {
+    let mut server_config = rustls::ServerConfig::builder()
+        .with_no_client_auth()
+        .with_single_cert(certs, key)
+        .expect("Certificate and key must be valid");
+    server_config.alpn_protocols = vec![b"h2".to_vec(), b"http/1.1".to_vec()];
+    let tls_acceptor = TlsAcceptor::from(Arc::new(server_config));
+
+    loop {
+        let (stream, addr) = listener.accept().await.unwrap();
+        let tls_acceptor = tls_acceptor.clone();
+
+        let gateway_config = gateway_config.clone();
+        let client_handler_service =
+            service_fn(move |req| handle_client(req, gateway_config.clone(), addr.ip()));
+        let base_service = ServiceBuilder::new()
+            .layer_fn(RequestID::new)
+            .layer_fn(AccessLogger::new)
+            .service(client_handler_service);
+        let handler_service = HandlerService::new(base_service, addr.ip());
+
+        tokio::spawn(async move {
+            let tls_stream = match tls_acceptor.accept(stream).await {
+                Ok(tls_stream) => tls_stream,
+                Err(err) => {
+                    tracing::error!("failed to perform tls handshake: {err:#}");
+                    return;
+                }
+            };
+            tracing::info!("Connected with client: {} over TLS", addr);
+
+            if let Err(err) = auto::Builder::new(TokioExecutor::new())
+                .serve_connection(TokioIo::new(tls_stream), handler_service)
+                .await
+            {
+                tracing::error!("Error serving connection: {err:#}");
+            }
+        });
+    }
+}
+
 async fn handle_client(
     request: Request<Incoming>,
     gateway_config: Arc<GatewayConfig>,
@@ -82,29 +159,29 @@ async fn handle_client(
             let proxy_uri_str = format!("{}{}", upstream_url, original_request.uri().path());
             let proxy_uri: Uri = match proxy_uri_str.parse() {
                 Ok(uri) => uri,
-                Err(_) => return Ok(response_with_status(StatusCode::BAD_GATEWAY)),
+                Err(_) => return Ok(bad_gateway_response()),
             };
 
             let proxy_host = match proxy_uri.host() {
                 Some(host) => host,
-                None => return Ok(response_with_status(StatusCode::BAD_GATEWAY)),
+                None => return Ok(bad_gateway_response()),
             };
 
             let proxy_port = match proxy_uri.port_u16() {
                 Some(port) => port,
-                None => return Ok(response_with_status(StatusCode::BAD_GATEWAY)),
+                None => return Ok(bad_gateway_response()),
             };
 
             let proxy_addr = format!("{proxy_host}:{proxy_port}");
             let stream = match TcpStream::connect(proxy_addr).await {
                 Ok(s) => s,
-                Err(_) => return Ok(response_with_status(StatusCode::BAD_GATEWAY)),
+                Err(_) => return Ok(bad_gateway_response()),
             };
 
             let aio = TokioIo::new(stream);
             let (mut sender, conn) = match http1_client::handshake(aio).await {
                 Ok(result) => result,
-                Err(_) => return Ok(response_with_status(StatusCode::BAD_GATEWAY)),
+                Err(_) => return Ok(bad_gateway_response()),
             };
 
             tokio::task::spawn(async move {
@@ -129,29 +206,52 @@ async fn handle_client(
 
             let proxy_req = match request_builder.body(original_request.into_body()) {
                 Ok(req) => req,
-                Err(_) => return Ok(response_with_status(StatusCode::BAD_GATEWAY)),
+                Err(_) => return Ok(bad_gateway_response()),
             };
 
             match sender.send_request(proxy_req).await {
                 Ok(proxy_res) => {
                     let mut response_builder = Response::builder().status(proxy_res.status());
                     for (key, value) in proxy_res.headers() {
+                        println!("{key}: {value:#?}");
                         if key != "content-length" || key != "server" {
                             response_builder = response_builder.header(key, value);
                         }
                     }
                     // Add server header
-                    response_builder = response_builder.header("Server", "portiq");
+                    response_builder = response_builder.header("server", "portiq");
 
                     let response_body = proxy_res.map(|b| b.boxed());
                     let res = response_builder.body(response_body.into_body()).unwrap();
                     Ok(res)
                 }
-                Err(_) => Ok(response_with_status(StatusCode::BAD_GATEWAY)),
+                Err(_) => Ok(bad_gateway_response()),
             }
         }
         Err(status_code) => Ok(response_with_status(status_code)),
     }
+}
+
+fn bad_gateway_response() -> Response<BoxBody<Bytes, hyper::Error>> {
+    let html_res = r#"<!DOCTYPE html>
+        <html>
+        <head>
+        <title>502 Bad Gateway</title>
+        </head>
+        <body>
+        <center><h1>502 Bad Gateway</h1></center>
+        <hr><center>portiq</center>
+        </body>
+        </html>"#;
+
+    let body = Full::new(Bytes::from_owner(html_res));
+    let boxed_body = BoxBody::new(body).map_err(|never| match never {}).boxed();
+    Response::builder()
+        .status(StatusCode::BAD_GATEWAY)
+        .header("Server", "portiq")
+        .header("Content-Type", "text/html; charset=utf-8")
+        .body(boxed_body)
+        .expect("Failed to construct response")
 }
 
 fn response_with_status(status_code: StatusCode) -> Response<BoxBody<Bytes, hyper::Error>> {
@@ -164,4 +264,30 @@ fn response_with_status(status_code: StatusCode) -> Response<BoxBody<Bytes, hype
                 .boxed(),
         )
         .unwrap()
+}
+
+// Load public certificate from file.
+fn load_certs(filename: &str) -> io::Result<Vec<CertificateDer<'static>>> {
+    // Open certificate file.
+    let certfile =
+        fs::File::open(filename).map_err(|e| error(format!("failed to open {filename}: {e}")))?;
+    let mut reader = io::BufReader::new(certfile);
+
+    // Load and return certificate.
+    rustls_pemfile::certs(&mut reader).collect()
+}
+
+// Load private key from file.
+fn load_private_key(filename: &str) -> io::Result<PrivateKeyDer<'static>> {
+    // Open keyfile.
+    let keyfile =
+        fs::File::open(filename).map_err(|e| error(format!("failed to open {filename}: {e}")))?;
+    let mut reader = io::BufReader::new(keyfile);
+
+    // Load and return a single private key.
+    rustls_pemfile::private_key(&mut reader).map(|key| key.unwrap())
+}
+
+fn error(err: String) -> io::Error {
+    io::Error::other(err)
 }


### PR DESCRIPTION
Added TLS support using the `rustls` crate to allow secure HTTPS communication. As a side effect, HTTP/2 support is now available. Configuration settings were updated to enable and manage TLS options.