### PR TITLE
feat(server): add graceful shutdown on SIGINT and SIGTERM with 5s delay

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1438,6 +1438,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
+name = "signal-hook-registry"
+version = "1.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9203b8055f63a2a00e2f593bb0510367fe707d7ff1e5c872de2f537b339e5410"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "slab"
 version = "0.4.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1612,6 +1621,7 @@ dependencies = [
  "libc",
  "mio",
  "pin-project-lite",
+ "signal-hook-registry",
  "slab",
  "socket2 0.6.0",
  "tokio-macros",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ http-body-util = "0.1.3"
 hyper = { version = "1.6.0", features = ["http1", "http2"] }
 hyper-util = { version = "0.1.16", features = ["server-auto", "tokio"] }
 serde = { version = "1.0.219", features = ["derive"] }
-tokio = { version = "1.47.1", features = ["rt-multi-thread", "macros"] }
+tokio = { version = "1.47.1", features = ["rt-multi-thread", "macros", "signal"] }
 tracing = "0.1.41"
 tracing-subscriber = { version = "0.3.19", features = ["json", "env-filter"] }
 uuid = { version = "1.17.0", features = ["v4"] }


### PR DESCRIPTION
### Summary

This PR adds graceful shutdown support to the server by handling `SIGINT` and `SIGTERM` signals.

### Details

* Listens for shutdown signals using Tokio’s async signal handling APIs.
* Stops accepting new connections immediately upon receiving a shutdown signal.
* Waits for 5 seconds before shutting down to allow inflight requests to complete.