### PR TITLE
feat(rate-limit): add basic in-memory rate limiting with token bucket

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -481,6 +481,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
 
 [[package]]
+name = "humantime"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b112acc8b3adf4b107a8ec20977da0273a8c386765a3ec0229bd500a1443f9f"
+
+[[package]]
+name = "humantime-serde"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57a3db5ea5923d99402c94e9feb261dc5ee9b4efa158b0315f788cf549cc200c"
+dependencies = [
+ "humantime",
+ "serde",
+]
+
+[[package]]
 name = "hyper"
 version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -989,6 +1005,7 @@ dependencies = [
  "async-trait",
  "config",
  "http-body-util",
+ "humantime-serde",
  "hyper",
  "hyper-util",
  "matchit",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,3 +21,4 @@ reqwest = { version = "0.12.22", features = ["rustls-tls"] }
 config = { version = "0.15.13", default-features = false, features = ["yaml"] }
 thiserror = "2.0.12"
 matchit = "0.8.6"
+humantime-serde = "1.1.1"

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,4 +1,5 @@
 use serde::Deserialize;
+use std::time::Duration;
 
 #[derive(Debug, Deserialize)]
 pub enum LogFormat {
@@ -22,9 +23,27 @@ pub struct AddPrefixConfig {
 }
 
 #[derive(Debug, Clone, Deserialize)]
+pub enum RateLimitKeySource {
+    #[serde(rename = "ip")]
+    IP(Option<String>),
+    #[serde(rename = "request_header")]
+    RequestHeader(String),
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct RateLimitConfig {
+    pub source: RateLimitKeySource,
+    pub limit: u32,
+    #[serde(with = "humantime_serde")]
+    pub period: Duration,
+}
+
+#[derive(Debug, Clone, Deserialize)]
 pub enum MiddlewareConfig {
     #[serde(rename = "add_prefix")]
     AddPrefix(AddPrefixConfig),
+    #[serde(rename = "rate_limit")]
+    RateLimit(RateLimitConfig),
 }
 
 #[derive(Debug, Deserialize)]

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,3 +1,5 @@
+#![deny(warnings)]
+
 use crate::config::{GatewayConfig, Protocol};
 use crate::error::RouterError;
 use crate::middleware::registry::MiddlewareRegistry;

--- a/src/main.rs
+++ b/src/main.rs
@@ -251,7 +251,10 @@ fn send_upstream(
     http_client: Arc<reqwest::Client>,
 ) -> HandlerFunc {
     Arc::new(move |req: Request<RequestBody>| {
-        let url = format!("{upstream_url}{}", req.uri());
+        let url = format!(
+            "{upstream_url}{}",
+            req.uri().path_and_query().unwrap().as_str()
+        );
 
         let host = if let Some(val) = req.headers().get("host") {
             String::from(val.to_str().unwrap())
@@ -292,7 +295,10 @@ fn send_upstream(
                         .unwrap();
                     Ok(response)
                 }
-                Err(_) => Ok(bad_gateway_response()),
+                Err(err) => {
+                    tracing::error!("Error sending request to upstream: {err:?}");
+                    Ok(bad_gateway_response())
+                }
             }
         })
     })

--- a/src/middleware/constants.rs
+++ b/src/middleware/constants.rs
@@ -1,3 +1,4 @@
 pub const REQUEST_ID_MIDDLEWARE: &str = "request_id";
 pub const ACCESS_LOGGER_MIDDLEWARE: &str = "access_logger";
 pub const ADD_PREFIX_MIDDLEWARE: &str = "add_prefix";
+pub const RATE_LIMIT_MIDDLEWARE: &str = "rate_limit";

--- a/src/middleware/mod.rs
+++ b/src/middleware/mod.rs
@@ -18,10 +18,13 @@ mod constants;
 
 mod add_prefix;
 
+mod rate_limiter;
+
 mod request_id;
 
 pub use access_logger::AccessLogger;
 pub use add_prefix::AddPrefixFactory;
+pub use rate_limiter::RateLimiterFactory;
 pub use request_id::RequestID;
 
 type Result<T> = std::result::Result<T, Infallible>;

--- a/src/middleware/rate_limiter/mod.rs
+++ b/src/middleware/rate_limiter/mod.rs
@@ -1,0 +1,42 @@
+use crate::config::MiddlewareConfig;
+use crate::middleware::Middleware;
+use crate::middleware::registry::MiddlewareFactory;
+use std::collections::HashMap;
+use std::sync::{Arc, Mutex};
+use std::time::Duration;
+
+mod token_bucket;
+
+pub trait RateLimiter {
+    fn allow(&self, key: &str) -> bool;
+
+    fn retry_after(&self, key: &str) -> Option<Duration>;
+}
+
+pub struct RateLimiterFactory {
+    store: Arc<Mutex<HashMap<String, token_bucket::TokenBucket>>>,
+}
+
+impl RateLimiterFactory {
+    pub fn new() -> Self {
+        RateLimiterFactory {
+            store: Arc::new(Mutex::new(HashMap::new())),
+        }
+    }
+}
+
+impl MiddlewareFactory for RateLimiterFactory {
+    fn create(&self, config: Option<MiddlewareConfig>) -> Arc<dyn Middleware> {
+        match config {
+            Some(MiddlewareConfig::RateLimit(cfg)) => {
+                Arc::new(token_bucket::TokenBucketRateLimiter::new(
+                    cfg.source,
+                    cfg.limit,
+                    cfg.period,
+                    Arc::clone(&self.store),
+                ))
+            }
+            _ => panic!("Invalid config for rate limiter"),
+        }
+    }
+}

--- a/src/middleware/rate_limiter/token_bucket.rs
+++ b/src/middleware/rate_limiter/token_bucket.rs
@@ -95,7 +95,7 @@ impl RateLimiter for TokenBucketRateLimiter {
         let store = self.store.lock().unwrap();
         if let Some(bucket) = store.get(key) {
             if bucket.available_tokens >= 1.0 {
-                Some(Duration::from_secs(0))
+                None
             } else {
                 let tokens_needed = 1.0 - bucket.available_tokens;
                 let seconds_to_wait = (tokens_needed / bucket.refill_rate).ceil() as u64;

--- a/src/middleware/rate_limiter/token_bucket.rs
+++ b/src/middleware/rate_limiter/token_bucket.rs
@@ -30,7 +30,6 @@ impl TokenBucket {
 
     fn allow(&mut self) -> bool {
         self.refill();
-
         if self.available_tokens >= 1.0 {
             self.available_tokens -= 1.0;
             true
@@ -89,13 +88,12 @@ impl RateLimiter for TokenBucketRateLimiter {
             let refill_rate = self.limit as f64 / self.duration.as_secs_f64();
             TokenBucket::new(capacity, refill_rate)
         });
-
         bucket.allow()
     }
 
     fn retry_after(&self, key: &str) -> Option<Duration> {
-        let mut store = self.store.lock().unwrap();
-        if let Some(bucket) = store.get_mut(key) {
+        let store = self.store.lock().unwrap();
+        if let Some(bucket) = store.get(key) {
             if bucket.available_tokens >= 1.0 {
                 Some(Duration::from_secs(0))
             } else {

--- a/src/middleware/rate_limiter/token_bucket.rs
+++ b/src/middleware/rate_limiter/token_bucket.rs
@@ -1,0 +1,228 @@
+use crate::config::RateLimitKeySource;
+use crate::middleware::rate_limiter::RateLimiter;
+use crate::middleware::{Middleware, Next, RequestBody, ResponseBody};
+use async_trait::async_trait;
+use http_body_util::{BodyExt, Empty};
+use hyper::body::Bytes;
+use hyper::{Request, Response, StatusCode};
+use std::collections::HashMap;
+use std::net::{IpAddr, Ipv4Addr};
+use std::sync::{Arc, Mutex};
+use std::time::{Duration, Instant};
+
+#[derive(Debug)]
+pub struct TokenBucket {
+    capacity: u32,
+    refill_rate: f64, // per-second
+    available_tokens: f64,
+    last_refill: Instant,
+}
+
+impl TokenBucket {
+    fn new(capacity: u32, refill_rate: f64) -> Self {
+        TokenBucket {
+            capacity,
+            refill_rate,
+            available_tokens: capacity as f64,
+            last_refill: Instant::now(),
+        }
+    }
+
+    fn allow(&mut self) -> bool {
+        self.refill();
+
+        if self.available_tokens >= 1.0 {
+            self.available_tokens -= 1.0;
+            true
+        } else {
+            false
+        }
+    }
+
+    fn refill(&mut self) {
+        let now = Instant::now();
+        let elapsed = now.duration_since(self.last_refill).as_secs_f64();
+        let tokens_to_add = self.refill_rate * elapsed;
+        if tokens_to_add > 0.0 {
+            let total_tokens = self.available_tokens + tokens_to_add;
+            self.available_tokens = if (self.capacity as f64) < total_tokens {
+                self.capacity as f64
+            } else {
+                total_tokens
+            };
+            self.last_refill = now;
+        }
+    }
+}
+
+pub struct TokenBucketRateLimiter {
+    source: RateLimitKeySource,
+    limit: u32,
+    duration: Duration,
+    store: Arc<Mutex<HashMap<String, TokenBucket>>>,
+}
+
+impl TokenBucketRateLimiter {
+    pub fn new(
+        source: RateLimitKeySource,
+        limit: u32,
+        duration: Duration,
+        store: Arc<Mutex<HashMap<String, TokenBucket>>>,
+    ) -> Self {
+        assert!(limit > 0, "Limit should be greater than 0");
+        assert!(duration.as_nanos() > 0, "Duration should be greater than 0");
+
+        TokenBucketRateLimiter {
+            source,
+            limit,
+            duration,
+            store,
+        }
+    }
+}
+
+impl RateLimiter for TokenBucketRateLimiter {
+    fn allow(&self, key: &str) -> bool {
+        let mut store = self.store.lock().unwrap();
+        let bucket = store.entry(key.to_string()).or_insert_with(|| {
+            let capacity = self.limit;
+            let refill_rate = self.limit as f64 / self.duration.as_secs_f64();
+            TokenBucket::new(capacity, refill_rate)
+        });
+
+        bucket.allow()
+    }
+
+    fn retry_after(&self, key: &str) -> Option<Duration> {
+        let mut store = self.store.lock().unwrap();
+        if let Some(bucket) = store.get_mut(key) {
+            if bucket.available_tokens >= 1.0 {
+                Some(Duration::from_secs(0))
+            } else {
+                let tokens_needed = 1.0 - bucket.available_tokens;
+                let seconds_to_wait = (tokens_needed / bucket.refill_rate).ceil() as u64;
+                Some(Duration::from_secs(seconds_to_wait))
+            }
+        } else {
+            None
+        }
+    }
+}
+
+#[async_trait]
+impl Middleware for TokenBucketRateLimiter {
+    async fn call(
+        &self,
+        req: Request<RequestBody>,
+        next: Next<'_>,
+    ) -> crate::middleware::Result<Response<ResponseBody>> {
+        let key = match &self.source {
+            RateLimitKeySource::IP(Some(header)) => {
+                if let Some(v) = req.headers().get(header) {
+                    v.to_str().unwrap_or("").to_string()
+                } else {
+                    req.extensions()
+                        .get::<IpAddr>()
+                        .unwrap_or(&IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)))
+                        .to_string()
+                }
+            }
+            RateLimitKeySource::IP(None) => req
+                .extensions()
+                .get::<IpAddr>()
+                .unwrap_or(&IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)))
+                .to_string(),
+            RateLimitKeySource::RequestHeader(header) => req
+                .headers()
+                .get(header)
+                .and_then(|v| v.to_str().ok())
+                .unwrap_or("-")
+                .to_string(),
+        };
+
+        if self.allow(&key) {
+            next.run(req).await
+        } else {
+            let retry_duration = self.retry_after(&key).unwrap_or(Duration::from_secs(0));
+            Ok(Response::builder()
+                .status(StatusCode::TOO_MANY_REQUESTS)
+                .header("Server", "portiq")
+                .header("Retry-After", retry_duration.as_secs())
+                .body(
+                    Empty::<Bytes>::new()
+                        .map_err(|never| match never {})
+                        .boxed(),
+                )
+                .expect("Response builder should not fail"))
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::thread::sleep;
+    // use std::thread::sleep;
+    use std::time::Duration;
+
+    #[test]
+    fn test_blocks_after_exceeding_limit() {
+        let key = "ajay:yadav";
+        let store = Mutex::new(HashMap::new());
+        let limiter = TokenBucketRateLimiter::new(
+            RateLimitKeySource::IP(None),
+            10,
+            Duration::from_secs(60),
+            Arc::new(store),
+        );
+        for _i in 1..=10 {
+            assert!(limiter.allow(key));
+        }
+        assert!(!limiter.allow(key));
+    }
+
+    #[test]
+    fn test_returns_retry_duration_on_limit_exceeded() {
+        let key = "ajay:yadav";
+        let store = Mutex::new(HashMap::new());
+        let limiter = TokenBucketRateLimiter::new(
+            RateLimitKeySource::IP(None),
+            1,
+            Duration::from_secs(5),
+            Arc::new(store),
+        );
+
+        // first request should pass
+        assert!(limiter.allow(key));
+
+        let retry = limiter.retry_after(key);
+        assert!(
+            retry.unwrap() >= Duration::from_secs(4) && retry.unwrap() <= Duration::from_secs(5)
+        );
+    }
+
+    #[test]
+    fn test_refills_tokens_over_time() {
+        let key = "ajay:yadav";
+        let store = Mutex::new(HashMap::new());
+        let limiter = TokenBucketRateLimiter::new(
+            RateLimitKeySource::IP(None),
+            3,
+            Duration::from_secs(2),
+            Arc::new(store),
+        );
+
+        // first 3 requests should pass
+        assert!(limiter.allow(key));
+        assert!(limiter.allow(key));
+        assert!(limiter.allow(key));
+
+        // this should fail
+        assert!(!limiter.allow(key));
+
+        sleep(Duration::from_secs(2));
+
+        // bucket refilled this should pass
+        assert!(limiter.allow(key));
+    }
+}

--- a/src/middleware/registry.rs
+++ b/src/middleware/registry.rs
@@ -1,8 +1,10 @@
 use crate::config::MiddlewareConfig;
 use crate::middleware::constants::{
-    ACCESS_LOGGER_MIDDLEWARE, ADD_PREFIX_MIDDLEWARE, REQUEST_ID_MIDDLEWARE,
+    ACCESS_LOGGER_MIDDLEWARE, ADD_PREFIX_MIDDLEWARE, RATE_LIMIT_MIDDLEWARE, REQUEST_ID_MIDDLEWARE,
 };
-use crate::middleware::{AccessLogger, AddPrefixFactory, Middleware, RequestID};
+use crate::middleware::{
+    AccessLogger, AddPrefixFactory, Middleware, RateLimiterFactory, RequestID,
+};
 use std::collections::HashMap;
 use std::sync::Arc;
 
@@ -20,6 +22,7 @@ impl MiddlewareRegistry {
         factories.insert(REQUEST_ID_MIDDLEWARE, Box::new(RequestID));
         factories.insert(ACCESS_LOGGER_MIDDLEWARE, Box::new(AccessLogger));
         factories.insert(ADD_PREFIX_MIDDLEWARE, Box::new(AddPrefixFactory));
+        factories.insert(RATE_LIMIT_MIDDLEWARE, Box::new(RateLimiterFactory::new()));
 
         MiddlewareRegistry { factories }
     }
@@ -50,6 +53,10 @@ impl MiddlewareRegistry {
                     .factories
                     .get(ADD_PREFIX_MIDDLEWARE)
                     .map(|factory| factory.create(Some(MiddlewareConfig::AddPrefix(cfg.clone())))),
+                MiddlewareConfig::RateLimit(cfg) => self
+                    .factories
+                    .get(RATE_LIMIT_MIDDLEWARE)
+                    .map(|factory| factory.create(Some(MiddlewareConfig::RateLimit(cfg.clone())))),
             })
             .collect::<Vec<_>>();
 


### PR DESCRIPTION
This PR adds a basic in-memory rate limiter using the token bucket algorithm.

Each request consumes a token from the bucket.

Tokens are replenished at a fixed rate until the bucket is full.

If no tokens are available, requests are rejected with HTTP 429 status code along with a Retry-After header.

This implementation is in-memory only, meaning limits apply per application instance and are not persisted between restarts.